### PR TITLE
Hotfix Search for curl or wget to continue installation

### DIFF
--- a/bin/_command_wrapper_run
+++ b/bin/_command_wrapper_run
@@ -4,13 +4,6 @@ current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 bin_path="`dirname $0`"
 root_dir="$( cd $bin_path && cd .. && pwd)"
 relative_path=${PWD#$root_dir}
-user_uid=1000
-user_group=1000
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    user_uid=501
-    user_group=20
-fi
 
 # Load project specific variables.
 set -o allexport
@@ -24,14 +17,8 @@ shift;
 container=$PROJECT_NAME
 container+="_$container_name"
 
-# If the input comes from a pipe or file ("< something.txt") we cant use "t" 
-#flag since it will fail with "the input device is not a TTY"
-# -t 0 == stdin
-if [ -t 0 ]; then
-  	tty="-it"
-else
-	tty="-i"
-fi
+## MOVE TO FOLDER where docker-compose yml files are located
+cd ${root_dir}
 
 command="docker-compose run --rm node /bin/bash -c 'cd /var/www/html$relative_path && $@'"
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
 
+###Define available downloader
+
+exists()
+{
+  command -v "$1" >/dev/null 2>&1
+}
+
+if exists curl; then
+  echo 'We are using curl to fetch the files !'
+  downloader="curl -L "
+elif exists wget; then
+  echo 'We are using wget to fetch the files !'
+  downloader="wget -O - "
+else
+  echo 'Your system does not have Wget nor Curl available.'
+  echo 'You need to provide one of them for this installer to work'
+  exit
+fi
+
 rm -rf /tmp/dockerizer
 
 echo "Installing dockerizer"
@@ -14,7 +33,7 @@ echo -e "Installing smartcd"
 
 # Install smartcd if not installed.
 if [ ! -f "$HOME/.smartcd_config" ]; then
-  curl -L http://smartcd.org/install | bash
+  $downloader http://smartcd.org/install | bash
 else
     echo -e "\e[32mCurrently installed\e[0m"
 fi


### PR DESCRIPTION
The install script will automatically use "curl" or "wget" to download the smartcd project.
If neither one is available, it will warn the user and stop the installation process.