### PR TITLE
Hotfix remove unneeded env parameters

### DIFF
--- a/bin/_command_wrapper_run
+++ b/bin/_command_wrapper_run
@@ -4,13 +4,6 @@ current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 bin_path="`dirname $0`"
 root_dir="$( cd $bin_path && cd .. && pwd)"
 relative_path=${PWD#$root_dir}
-user_uid=1000
-user_group=1000
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    user_uid=501
-    user_group=20
-fi
 
 # Load project specific variables.
 set -o allexport
@@ -24,14 +17,8 @@ shift;
 container=$PROJECT_NAME
 container+="_$container_name"
 
-# If the input comes from a pipe or file ("< something.txt") we cant use "t" 
-#flag since it will fail with "the input device is not a TTY"
-# -t 0 == stdin
-if [ -t 0 ]; then
-  	tty="-it"
-else
-	tty="-i"
-fi
+## MOVE TO FOLDER where docker-compose yml files are located
+cd ${root_dir}
 
 command="docker-compose run --rm node /bin/bash -c 'cd /var/www/html$relative_path && $@'"
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -38,6 +38,9 @@ services:
   apache:
     network_mode: traefik_default
     environment:
+      # By default, PROJECT_BASE_PATH path is empty, but you can change this value
+      # inside of the .env file
+      PROJECT_BASE_PATH: ${PROJECT_BASE_PATH:-}
       # For xdebug when we hold a breakpoint we need the server
       # wait until we release the request. APACHE_FCGI_PROXY_TIMEOUT
       # prevent the "Gateway Timeout"

--- a/example.docker.env
+++ b/example.docker.env
@@ -3,8 +3,9 @@
 
 PROJECT_NAME=dockerizer
 PROJECT_BASE_URL=dockerizer.localhost
-# If your project resides in a subdir you can specify it on PROJECT_BASE_PATH
-PROJECT_BASE_PATH=
+# If your project resides in a subdir of the "web" folder you can specify it on PROJECT_BASE_PATH
+# By default, it is empty
+#PROJECT_BASE_PATH=
 
 DB_NAME=db
 DB_USER=db
@@ -16,31 +17,33 @@ DB_DRIVER=mysql
 # ----------------------------------------------------------------------------
 ### --- MARIADB ----
 
-MARIADB_TAG=10.3-3.4.11
-#MARIADB_TAG=10.3-3.4.11
-#MARIADB_TAG=10.1-3.4.11
+MARIADB_TAG=10.3-3.6.0
+#MARIADB_TAG=10.3-3.6.0
+#MARIADB_TAG=10.1-3.6.0
 
 # ----------------------------------------------------------------------------
 ### --- PHP ----
 
 # Linux (uid 1000 gid 1000)
 
-PHP_TAG=7.3-dev-4.12.12
-#PHP_TAG=7.2-dev-4.12.12
-#PHP_TAG=7.1-dev-4.12.12
-#PHP_TAG=5.6-dev-4.12.12
+PHP_TAG=7.3-dev-4.13.0
+#PHP_TAG=7.2-dev-4.13.0
+#PHP_TAG=7.1-dev-4.13.0
+#PHP_TAG=5.6-dev-4.13.0
 
 # macOS (uid 501 gid 20)
 
-#PHP_TAG=7.3-dev-macos-4.12.12
-#PHP_TAG=7.2-dev-macos-4.12.12
-#PHP_TAG=7.1-dev-macos-4.12.12
-#PHP_TAG=5.6-dev-macos-4.12.12
+#PHP_TAG=7.3-dev-macos-4.13.0
+#PHP_TAG=7.2-dev-macos-4.13.0
+#PHP_TAG=7.1-dev-macos-4.13.0
+#PHP_TAG=5.6-dev-macos-4.13.0
 
 # ----------------------------------------------------------------------------
 ### OTHERS
 
-APACHE_TAG=2.4-4.0.7
+APACHE_TAG=2.4-4.1.0
+#APACHE_TAG=2.4-4.0.7
+#APACHE_TAG=2-4.1.0
 
 # ----------------------------------------------------------------------------
 ### --- CUSTOM VARS ----
@@ -63,4 +66,6 @@ APACHE_TAG=2.4-4.0.7
 #MYSQL_QUERY_CACHE_SIZE=0
 
 # Dockerizer customs
-POSTGRESS_TAG=latest
+POSTGRESS_TAG=11-1.7.0
+#POSTGRESS_TAG=latest
+#POSTGRESS_TAG=10-1.7.0

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
 
+###Define available downloader
+
+exists()
+{
+  command -v "$1" >/dev/null 2>&1
+}
+
+if exists curl; then
+  echo 'We are using curl to fetch the files !'
+  downloader="curl -L "
+elif exists wget; then
+  echo 'We are using wget to fetch the files !'
+  downloader="wget -O - "
+else
+  echo 'Your system does not have Wget nor Curl available.'
+  echo 'You need to provide one of them for this installer to work'
+  exit
+fi
+
 rm -rf /tmp/dockerizer
 
 echo "Installing dockerizer"
@@ -14,7 +33,7 @@ echo -e "Installing smartcd"
 
 # Install smartcd if not installed.
 if [ ! -f "$HOME/.smartcd_config" ]; then
-  curl -L http://smartcd.org/install | bash
+  $downloader http://smartcd.org/install | bash
 else
     echo -e "\e[32mCurrently installed\e[0m"
 fi


### PR DESCRIPTION
Actually, only the PROJECT_BASE_PATH env variable should be pushed into
the docker-compose.override.yml file.

Other values shall be present for the dk command to work properly.

I updated the other env vars ( service tags ) to their latest non alpha
versions, to enable users to adjust their values to their projects
needs.

#94 